### PR TITLE
Add date field to the news

### DIFF
--- a/app/features/api/types.ts
+++ b/app/features/api/types.ts
@@ -139,6 +139,7 @@ export type TApiWorkshop = IApiItem<{
 
 export type TApiNews = IApiItem<{
   content: string
+  date: string
   detailsSection: TApiDetailsSection[]
   gallery: IApiGallery
   events: IApiRelationMultiple<TApiEvent>

--- a/app/utils/map-api-news-to-tile.ts
+++ b/app/utils/map-api-news-to-tile.ts
@@ -4,9 +4,9 @@ import {ITileProps} from '@/app/components/ui'
 import {siteMap} from '@/app/dictionaries/site.dictionary'
 import {TApiNews} from '@/app/features/api'
 
-export const mapApiNewsToTile = ({attributes: {publishedAt, slug, teaser, title}}: TApiNews): ITileProps => {
+export const mapApiNewsToTile = ({attributes: {date, slug, teaser, title}}: TApiNews): ITileProps => {
   return {
-    date: dayjs(publishedAt),
+    date: dayjs(date),
     link: `${siteMap.news}/${slug}`,
     teaser,
     title,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const ids = events?.data.map(({id}) => id.toString()) ?? []
 
   const payloads: [IGetApiCollectionResponseParams<TApiNews>, IGetApiCollectionResponseParams<TApiEvent>] = [
-    {endpoint: 'news', pagination: {limit: 2}, sort: [['id', 'desc']]},
+    {endpoint: 'news', pagination: {limit: 2}, sort: [['date', 'desc']]},
     {endpoint: 'events', filters: [{key: 'id', value: ids, operator: 'containsi'}], populate: [['location'], ['thumbnail']]},
   ]
   const {dehydratedState} = await getDehydratedState<TApiNews & TApiEvent>({payloads, req})

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -17,7 +17,7 @@ const Page: NextPage<IPageWithPayload<[TApiNews]>> = ({payloads: [payload]}) => 
       <Title ref={scrollRef} cs={{mb: [theme.spacing.l, theme.spacing.xxl]}}>
         Aktualności
       </Title>
-      <DynamicContent payload={payload} filters={[{type: 'datepicker', key: 'publishedAt'}]} scrollToElement={scrollToElement}>
+      <DynamicContent payload={payload} filters={[{type: 'datepicker', key: 'date'}]} scrollToElement={scrollToElement}>
         {(data) => (
           <TilesList
             cols={[1, 2, 3]}
@@ -32,7 +32,7 @@ const Page: NextPage<IPageWithPayload<[TApiNews]>> = ({payloads: [payload]}) => 
 }
 
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
-  const payloads: IGetApiCollectionResponseParams<TApiNews>[] = [{endpoint: 'news', sort: [['id', 'desc']]}]
+  const payloads: IGetApiCollectionResponseParams<TApiNews>[] = [{endpoint: 'news', sort: [['date', 'desc']]}]
   const {dehydratedState} = await getDehydratedState({payloads, req})
 
   return {


### PR DESCRIPTION
# Add date field to the news

## Changelog

- Changed display value and filter key from `createdAt` to newly created field `date` in news items.
