### PR TITLE
Missing pieces for covers

### DIFF
--- a/app/components/ui/cover-item.tsx
+++ b/app/components/ui/cover-item.tsx
@@ -38,11 +38,6 @@ export const CoverItem: FC<ICoverItemProps> = ({date, link, tags, teaser, title}
           ))}
         </Box>
       )}
-      <Box tag="ul" composition={['semanticList']} cs={{display: 'flex', flexWrap: 'wrap', gap: theme.spacing.s, mb: theme.spacing.m}}>
-        <Box key={123} tag="li">
-          <Tag>Tag</Tag>
-        </Box>
-      </Box>
       {date && (
         <Text tag="span" cs={{mb: theme.spacing.xxs, color: theme.color.white}}>
           {Array.isArray(date) ? getFormattedDateRange(...date) : date.format('DD/MM/YYYY')}

--- a/app/components/ui/cover-item.tsx
+++ b/app/components/ui/cover-item.tsx
@@ -33,7 +33,7 @@ export const CoverItem: FC<ICoverItemProps> = ({date, link, tags, teaser, title}
         <Box tag="ul" composition={['semanticList']} cs={{display: 'flex', flexWrap: 'wrap', gap: theme.spacing.s, mb: theme.spacing.m}}>
           {tags.map((tag, i) => (
             <Box key={i} tag="li">
-              <Tag>{tag}</Tag>
+              <Tag inverse>{tag}</Tag>
             </Box>
           ))}
         </Box>

--- a/app/components/ui/tag.tsx
+++ b/app/components/ui/tag.tsx
@@ -7,12 +7,13 @@ import {theme} from '@/app/styles'
 interface ITagProps {
   close?: boolean
   icon?: boolean
+  inverse?: boolean
   onClick?(): void
 }
 
 export const tagHoverParent = 'tag-hover-parent'
 
-export const Tag: FC<PropsWithChildren<ITagProps>> = ({children, close, icon = true, onClick}) => {
+export const Tag: FC<PropsWithChildren<ITagProps>> = ({children, close, icon = true, inverse, onClick}) => {
   return (
     <Box
       cs={{
@@ -22,10 +23,10 @@ export const Tag: FC<PropsWithChildren<ITagProps>> = ({children, close, icon = t
         columnGap: theme.spacing.xxs,
         px: theme.spacing.xs,
         py: theme.spacing.xxs,
-        color: theme.color.white,
+        color: inverse ? theme.color.primary : theme.color.white,
         fontSize: theme.font.size.small,
         textTransform: 'uppercase',
-        bg: theme.color.text,
+        bg: inverse ? theme.color.white : theme.color.text,
         borderRadius: theme.radii.s,
         transition: 'color 200ms, background-color 200ms',
         ...(close && {

--- a/app/features/api/types.ts
+++ b/app/features/api/types.ts
@@ -159,14 +159,17 @@ export type TApiHomePage = IApiItem<{
 
 export type TApiNewsLandingPage = IApiItem<{
   cover: IApiImage
+  coverMobile?: IApiImage
 }>
 
 export type TApiEventsLandingPage = IApiItem<{
   cover: IApiImage
+  coverMobile?: IApiImage
 }>
 
 export type TApiWorkshopsLandingPage = IApiItem<{
   cover: IApiImage
+  coverMobile?: IApiImage
   intro: string
   workshops?: {
     data: {
@@ -177,6 +180,7 @@ export type TApiWorkshopsLandingPage = IApiItem<{
 
 export type TApiFacilitiesLandingPage = IApiItem<{
   cover: IApiImage
+  coverMobile?: IApiImage
   intro: string
   facilities?: {
     data: {
@@ -188,6 +192,7 @@ export type TApiFacilitiesLandingPage = IApiItem<{
 export type TApiAboutUsPage = IApiItem<{
   content: TApiDynamicZone[]
   cover: IApiImage
+  coverMobile?: IApiImage
 }>
 
 export type TApiCommonItem = IApiItem<unknown>

--- a/pages/about-us/index.tsx
+++ b/pages/about-us/index.tsx
@@ -8,6 +8,7 @@ import {getApiSingleResponse, IApiImage, TApiAboutUsPage} from '@/app/features/a
 
 interface IAboutUsPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
   zones: TApiDynamicZone[]
 }
 
@@ -24,12 +25,20 @@ const Page: NextPage<IAboutUsPageProps> = ({cover, zones}) => {
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {
     data: {
-      attributes: {content, cover},
+      attributes: {content, cover, coverMobile},
     },
-  } = await getApiSingleResponse<TApiAboutUsPage>({req, endpoint: 'about-us', populateRaw: {...populateDynamicZone, cover: '*'}})
+  } = await getApiSingleResponse<TApiAboutUsPage>({
+    req,
+    endpoint: 'about-us',
+    populateRaw: {...populateDynamicZone, cover: '*', coverMobile: '*'},
+  })
 
   return {
-    props: {zones: content, cover},
+    props: {
+      cover,
+      coverMobile,
+      zones: content,
+    },
   }
 }
 

--- a/pages/events/[...slug].tsx
+++ b/pages/events/[...slug].tsx
@@ -19,6 +19,7 @@ import {
 
 interface IEventPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
 }
 
 const Page: NextPage<IPageWithPayload<[TApiEvent]> & IEventPageProps> = ({payloads: [payload], cover}) => {
@@ -42,12 +43,12 @@ const Page: NextPage<IPageWithPayload<[TApiEvent]> & IEventPageProps> = ({payloa
 export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
   const {
     data: {
-      attributes: {cover},
+      attributes: {cover, coverMobile},
     },
   } = await getApiSingleResponse<TApiEventsLandingPage>({
     req,
     endpoint: 'events-landing-page',
-    populate: ['cover'],
+    populate: ['cover', 'coverMobile'],
   })
 
   const [slug] = query.slug as string[]
@@ -58,7 +59,12 @@ export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
 
   return hasData
     ? {
-        props: {dehydratedState, payloads, cover},
+        props: {
+          cover,
+          coverMobile,
+          dehydratedState,
+          payloads,
+        },
       }
     : {
         notFound: true,

--- a/pages/events/index.tsx
+++ b/pages/events/index.tsx
@@ -23,6 +23,7 @@ import {mapApiEventToTile, sortByIdList} from '@/app/utils'
 
 interface IEventsPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
   locations: ISelectOption[]
   promotedEvents: TApiEvent[]
 }
@@ -78,12 +79,12 @@ const Page: NextPage<IPageWithPayload<[TApiEvent, TApiEvent]> & IEventsPageProps
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {
     data: {
-      attributes: {cover},
+      attributes: {cover, coverMobile},
     },
   } = await getApiSingleResponse<TApiEventsLandingPage>({
     req,
     endpoint: 'events-landing-page',
-    populate: ['cover'],
+    populate: ['cover', 'coverMobile'],
   })
   const {
     data: {
@@ -108,7 +109,14 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {dehydratedState} = await getDehydratedState({payloads, req})
 
   return {
-    props: {dehydratedState, cover, locations, payloads, promotedEvents},
+    props: {
+      cover,
+      coverMobile,
+      dehydratedState,
+      locations,
+      payloads,
+      promotedEvents,
+    },
   }
 }
 

--- a/pages/facilities/index.tsx
+++ b/pages/facilities/index.tsx
@@ -23,6 +23,7 @@ import {sortByIdList} from '@/app/utils'
 
 interface IWorkshopPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
   ids: string[]
   intro: string
 }
@@ -55,12 +56,12 @@ const Page: NextPage<IPageWithPayload<[TApiFacility]> & IWorkshopPageProps> = ({
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {
     data: {
-      attributes: {cover, intro, facilities},
+      attributes: {cover, coverMobile, intro, facilities},
     },
   } = await getApiSingleResponse<TApiFacilitiesLandingPage>({
     req,
     endpoint: 'facilities-landing-page',
-    populate: ['cover', 'facilities'],
+    populate: ['cover', 'coverMobile', 'facilities'],
   })
   const ids = facilities?.data.map(({id}) => id.toString()) ?? []
 
@@ -70,7 +71,14 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {dehydratedState} = await getDehydratedState({payloads, req})
 
   return {
-    props: {dehydratedState, cover, intro, ids, payloads},
+    props: {
+      cover,
+      coverMobile,
+      dehydratedState,
+      ids,
+      intro,
+      payloads,
+    },
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
   } = await getApiSingleResponse<TApiHomePage>({
     req,
     endpoint: 'home-page',
-    populateRaw: {events: '*', slider: {populate: ['event', 'cover']}},
+    populateRaw: {events: '*', slider: {populate: {event: {populate: ['location']}, cover: '*'}}},
   })
   const ids = events?.data.map(({id}) => id.toString()) ?? []
 

--- a/pages/news/[...slug].tsx
+++ b/pages/news/[...slug].tsx
@@ -19,6 +19,7 @@ import {
 
 interface INewPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
 }
 
 const Page: NextPage<IPageWithPayload<[TApiNews]> & INewPageProps> = ({payloads: [payload], cover}) => {
@@ -42,12 +43,12 @@ const Page: NextPage<IPageWithPayload<[TApiNews]> & INewPageProps> = ({payloads:
 export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
   const {
     data: {
-      attributes: {cover},
+      attributes: {cover, coverMobile},
     },
   } = await getApiSingleResponse<TApiNewsLandingPage>({
     req,
     endpoint: 'news-landing-page',
-    populate: ['cover'],
+    populate: ['cover', 'coverMobile'],
   })
   const [slug] = query.slug as string[]
   const payloads: IGetApiCollectionResponseParams<TApiNews>[] = [
@@ -57,7 +58,12 @@ export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
 
   return hasData
     ? {
-        props: {dehydratedState, payloads, cover},
+        props: {
+          cover,
+          coverMobile,
+          dehydratedState,
+          payloads,
+        },
       }
     : {
         notFound: true,

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -19,6 +19,7 @@ import {mapApiNewsToTile} from '@/app/utils'
 
 interface INewsPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
 }
 
 const Page: NextPage<IPageWithPayload<[TApiNews]> & INewsPageProps> = ({cover, payloads: [payload]}) => {
@@ -46,18 +47,23 @@ const Page: NextPage<IPageWithPayload<[TApiNews]> & INewsPageProps> = ({cover, p
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {
     data: {
-      attributes: {cover},
+      attributes: {cover, coverMobile},
     },
   } = await getApiSingleResponse<TApiNewsLandingPage>({
     req,
     endpoint: 'news-landing-page',
-    populate: ['cover'],
+    populate: ['cover', 'coverMobile'],
   })
   const payloads: IGetApiCollectionResponseParams<TApiNews>[] = [{endpoint: 'news', sort: [['date', 'desc']]}]
   const {dehydratedState} = await getDehydratedState({payloads, req})
 
   return {
-    props: {dehydratedState, cover, payloads},
+    props: {
+      cover,
+      coverMobile,
+      dehydratedState,
+      payloads,
+    },
   }
 }
 

--- a/pages/workshops/[...slug].tsx
+++ b/pages/workshops/[...slug].tsx
@@ -19,6 +19,7 @@ import {
 
 interface IWorkshopPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
 }
 
 const Page: NextPage<IPageWithPayload<[TApiWorkshop]> & IWorkshopPageProps> = ({payloads: [payload], cover}) => {
@@ -42,12 +43,12 @@ const Page: NextPage<IPageWithPayload<[TApiWorkshop]> & IWorkshopPageProps> = ({
 export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
   const {
     data: {
-      attributes: {cover},
+      attributes: {cover, coverMobile},
     },
   } = await getApiSingleResponse<TApiWorkshopsLandingPage>({
     req,
     endpoint: 'workshops-landing-page',
-    populate: ['cover'],
+    populate: ['cover', 'coverMobile'],
   })
   const [slug] = query.slug as string[]
   const payloads: IGetApiCollectionResponseParams<TApiWorkshop>[] = [
@@ -61,7 +62,12 @@ export const getServerSideProps: GetServerSideProps = async ({query, req}) => {
 
   return hasData
     ? {
-        props: {dehydratedState, payloads, cover},
+        props: {
+          cover,
+          coverMobile,
+          dehydratedState,
+          payloads,
+        },
       }
     : {
         notFound: true,

--- a/pages/workshops/index.tsx
+++ b/pages/workshops/index.tsx
@@ -21,6 +21,7 @@ import {mapApiWorkshopToTile, sortByIdList} from '@/app/utils'
 
 interface IWorkshopPageProps {
   cover: IApiImage
+  coverMobile?: IApiImage
   ids: string[]
   intro: string
 }
@@ -64,12 +65,12 @@ const Page: NextPage<IPageWithPayload<[TApiWorkshop]> & IWorkshopPageProps> = ({
 export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {
     data: {
-      attributes: {cover, intro, workshops},
+      attributes: {cover, coverMobile, intro, workshops},
     },
   } = await getApiSingleResponse<TApiWorkshopsLandingPage>({
     req,
     endpoint: 'workshops-landing-page',
-    populate: ['cover', 'workshops'],
+    populate: ['cover', 'coverMobile', 'workshops'],
   })
   const ids = workshops?.data.map(({id}) => id.toString()) ?? []
 
@@ -79,7 +80,14 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
   const {dehydratedState} = await getDehydratedState({payloads, req})
 
   return {
-    props: {dehydratedState, cover, intro, ids, payloads},
+    props: {
+      cover,
+      coverMobile,
+      dehydratedState,
+      ids,
+      intro,
+      payloads,
+    },
   }
 }
 


### PR DESCRIPTION
# Missing pieces for covers

Added missing details required to finish up covers and slider features.

## Changelog

- Added `inverted` vartiant to `Tag` component.
- Fixed `populate` config for homepage request - added loading of the locations.
- Added support for additional prop to all the pages - `coverMobile`.